### PR TITLE
Add event handler to discard FSM from app db

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,21 @@ Still early, expecting minor bugs and possibly some breaking APIs in the short t
 (rf/dispatch [::http/start fsm])
 
 ;; The FSM provides you with a simple data representation of where we are in the process
-(rf/subscribe [::http/state :customer-loader])
+(def state (rf/subscribe [::http/state :customer-loader]))
 
+@state
 ;; => [:glimt.core/loading]
 
-;; First request failed, trying again
+;; First request failed, because of transient error, trying again
+@state
 ;; => [:glimt.core/error :glimt.core/retrying :glimt.core/loading]
 
 ;; Request succeeded, machine reached it success end state
+@state
 ;; => [:glimt.core/loaded]
 
-(rf/subscribe [::http/state-full :customer-loader])
-;; After trying again 5 times, FSM reaches its failure end state
+;; Or, if after trying again 5 times, FSM reaches its failure end state
+@(rf/subscribe [::http/state-full :customer-loader])
 ;; => {:_state [:glimt.core/error :glimt.core/halted] 
 ;;     :error  {:uri             "/error"
 ;;              :last-method     "GET"
@@ -50,6 +53,12 @@ Still early, expecting minor bugs and possibly some breaking APIs in the short t
 ;;              :status-text     "Service Unavailable"
 ;;              :failure         :error
 ;;              :response        nil}]}
+
+;; At your leisure, remove FSM from app db
+(rf/dispatch [::http/discard :customer-loader])
+
+@state
+;; => nil
 ```
 
 # FSM configuration

--- a/src/glimt/core.cljc
+++ b/src/glimt/core.cljc
@@ -152,6 +152,12 @@
     (let [init-event (ns-key id "init")]
       {:dispatch [init-event]})))
 
+(f/reg-event-db ::discard
+ ;; Removes the fsm identified by `id` from the app db. Does not attempt to halt
+ ;; any in-flight requests.
+ (fn [db [_ id]]
+   (update db ::fsm-state dissoc id)))
+
 (f/reg-event-fx ::start
   ;; Starts the interceptor for the given fsm.
   (fn [_ [_ fsm]]


### PR DESCRIPTION
### Proposal
Add an event handler that discards an FSM (identified by its id) from the app db.

### Use case
I have a list of items. Each item is initially loaded with a small amount of data, and then I asynchronously fetch more details about each one. I have an FSM for each item, so I can show the progress of its request.

The list might contain thousands of items, so this accumulates thousands of state objects in the app db, even though I don't  need them after the FSM has finished loading.

This new event handler lets me clean up the state objects, with code something like this:
```clojure
(defn fsm [item-id]
  (let [fsm-id (keyword "item" item-id)]
    {:id          fsm-id
     :http-xhrio  {:uri             (str "https://example.com/items/" item-id)
                   :method          :get
                   :response-format (ajax/json-response-format {:keywords? true})}
     :on-success  [::loaded fsm-id item-id]}))

(re-frame/reg-event-fx
 ::loaded
 (fn [{:keys [db]} [_ fsm-id item-id result]]
   {:db (assoc-in db [:items item-id] result)
    ;; delay, to briefly show a "Loaded!" message in the UI.
    :fx [[:dispatch-later {:ms 1000, :dispatch [::http/discard fsm-id]}]]}))
```

### Alternatives considered
* Do nothing. The state objects usually aren't very big. If many of them fail, they become larger because they store their errors. But ... memory is cheap?
* Add a `:discard-delay` key to the FSM config. If the key is present, upon entering the `::loaded` state, discard the FSM after the delay (or immediately if the delay is 0). This solution is declarative, but isn't very flexible. Perhaps you also want to discard after halting in an error state. Or maybe you only want to discard if the response contains some particular data. I can imagine adding something like `:discard-delay` eventually, but the new event handler seems like a good first step, and would probably be a building block of `:discard-delay` anyway.
* Always discard after some fixed delay. Would be a breaking change and probably doesn't fit all use cases.

### Concerns
Perhaps this is all misguided... Under the covers, `statecharts` [registers](https://github.com/lucywang000/clj-statecharts/blob/df37e27bde149b0a64b65a5f4390ce21a0431549/src/statecharts/integrations/re_frame.cljc#L96) [two](https://github.com/lucywang000/clj-statecharts/blob/df37e27bde149b0a64b65a5f4390ce21a0431549/src/statecharts/integrations/re_frame.cljc#L105) event handlers **for each fsm-id**. Each of these handlers closes over the whole FSM (not the FSM state). `statecharts` doesn't [un-register](https://day8.github.io/re-frame/api-re-frame.core/#clear-event) event handlers (though if you re-use a fsm-id, it will re-register them). So, I should be much more worried about memory leaks that arise from registering thousands of FSMs with `statecharts`. From that perspective, perhaps the first place to focus effort is on the `statecharts`/`re-frame` integration. Or perhaps there's some way to create a single FSM that manages multiple similar but slightly different requests. Needs more research.