### PR TITLE
Avoid memory leaks by storing machine and states in the app-db

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,6 @@
  :aliases {:build {:deps       {io.github.seancorfield/build-clj
                                 {:git/tag "v0.5.0" :git/sha "2ceb95a"}}
                    :ns-default build}}
- :deps    {re-frame/re-frame               {:mvn/version "1.1.1"}
-           day8.re-frame/http-fx           {:mvn/version "v0.2.0"}
-           clj-statecharts/clj-statecharts {:mvn/version "0.1.0"}}}
+ :deps    {re-frame/re-frame                          {:mvn/version "1.1.1"}
+           day8.re-frame/http-fx                      {:mvn/version "v0.2.0"}
+           com.github.mainej/clj-statecharts-re-frame {:git/sha "dfe9359dffa0f9879fa9abd8fc5051a02d0d8f5d"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,4 +4,4 @@
                    :ns-default build}}
  :deps    {re-frame/re-frame                          {:mvn/version "1.1.1"}
            day8.re-frame/http-fx                      {:mvn/version "v0.2.0"}
-           com.github.mainej/clj-statecharts-re-frame {:git/sha "dfe9359dffa0f9879fa9abd8fc5051a02d0d8f5d"}}}
+           com.github.mainej/clj-statecharts-re-frame {:git/sha "c9fcd5e82e720fd0722592df27cdc07555085250"}}}

--- a/src/glimt/multi_state.cljc
+++ b/src/glimt/multi_state.cljc
@@ -1,12 +1,14 @@
 (ns glimt.multi-state
-  (:require [malli.core :as m]
-            [malli.error :as me]
-            [malli.transform :as mt]
-            [malli.util :as mu]
-            [re-frame.core :as f]
-            [statecharts.core :as sc]
-            [statecharts.utils :as sc.utils]
-            [mainej.statecharts.integrations.re-frame :as sc.rf]))
+  (:require
+   [day8.re-frame.http-fx]
+   [mainej.statecharts.integrations.re-frame :as sc.rf]
+   [malli.core :as m]
+   [malli.error :as me]
+   [malli.transform :as mt]
+   [malli.util :as mu]
+   [re-frame.core :as f]
+   [statecharts.core :as sc]
+   [statecharts.utils :as sc.utils]))
 
 (def default-fsm-id ::fsm)
 (def default-fsm-path [default-fsm-id])

--- a/src/glimt/multi_state.cljc
+++ b/src/glimt/multi_state.cljc
@@ -155,8 +155,7 @@
                                (update :http-xhrio assoc
                                        :on-success [::sc.rf/transition ::success transition-data]
                                        :on-failure [::sc.rf/transition ::error transition-data]))]
-       {:dispatch [::sc.rf/initialize transition-data {:id      (:state-path transition-data)
-                                                       :context {:request request}}]}))))
+       {:dispatch [::sc.rf/initialize transition-data {:context {:request request}}]}))))
 
 ;; Restart a request, which presumably finished either at [::error ::halted] or
 ;; [::loaded]. Note that the entire request isn't needed, only the `:id` and,
@@ -165,11 +164,9 @@
 (f/reg-event-fx
  ::restart
  (fn [{:keys [db]} [_ request]]
-   (let [transition-data (request-transition-data request)
-         state-path      (:state-path transition-data)]
-     (when-let [existing-context (get-in db state-path)]
-       {:dispatch [::sc.rf/initialize transition-data {:id      state-path
-                                                       :context existing-context}]}))))
+   (let [transition-data (request-transition-data request)]
+     (when-let [existing-context (get-in db (:state-path transition-data))]
+       {:dispatch [::sc.rf/initialize transition-data {:context existing-context}]}))))
 
 ;; Removes the request identified by `request-id` from the app db. Does not
 ;; attempt to halt an in-flight request, though any transitions for the request

--- a/src/glimt/multi_state.cljc
+++ b/src/glimt/multi_state.cljc
@@ -75,9 +75,7 @@
   (assoc state :error (:data event)))
 
 (defn- dispatch-callback [event-vector-name]
-  (fn [state event]
-    (when-let [event-vector (get-in state [:request event-vector-name])]
-      (f/dispatch (vec (concat event-vector [state event]))))))
+  (sc.rf/dispatch-callback [:request event-vector-name]))
 
 (defn dispatch-xhrio [state event]
   (sc.rf/call-fx {:http-xhrio (get-in state [:request :http-xhrio])}))

--- a/src/glimt/multi_state.cljc
+++ b/src/glimt/multi_state.cljc
@@ -120,10 +120,21 @@
                                   ::halted   {}}}
              ::loaded  {}}})
 
+;; Register a `machine`, saving it at `fsm-path`. This is merely a convenience
+;; alias for `::sc.rf/register`. It can be useful to avoid an extra require if
+;; you need to register a machine that has a glimt embedded machine within it.
+;; After a machine has been registered, start a request for it by dispatching
+;; `::http/start` with the `fsm-path` provided here as the request's
+;; `:fsm-path`.
+(f/reg-event-fx
+ ::register
+ (fn [_ [_ fsm-path machine]]
+   {:dispatch [::sc.rf/register fsm-path machine]}))
+
 ;; Register the default FSM. If a request doesn't include an `:fsm-path`, this
 ;; FSM will be used.
 (let [machine (assoc (embedded-fsm {:state-path [:>]}) :id default-fsm-id)]
-  (f/dispatch [::sc.rf/register default-fsm-path (sc/machine machine)]))
+  (f/dispatch [::register default-fsm-path (sc/machine machine)]))
 
 (defn request-state-path [request-id]
   (into [::requests] (sc.utils/ensure-vector request-id)))

--- a/src/glimt/multi_state.cljc
+++ b/src/glimt/multi_state.cljc
@@ -1,0 +1,180 @@
+(ns glimt.multi-state
+  (:require [malli.core :as m]
+            [malli.error :as me]
+            [malli.transform :as mt]
+            [malli.util :as mu]
+            [re-frame.core :as f]
+            [statecharts.core :as sc]
+            [statecharts.utils :as sc.utils]
+            [statecharts.integrations.re-frame-multi :as sc.rf]))
+
+(def request-map-schema-def
+  [:and
+   [:map
+    [:fsm/id :keyword]
+    [:request/id vector?]
+    [:http-xhrio :map]
+    [:path {:optional true} vector?]
+    [:on-success {:optional true} vector?]
+    [:on-loading {:optional true} vector?]
+    [:on-error {:optional true} vector?]
+    [:on-failure {:optional true} vector?]]
+   [:fn {:error/message "Should contain either path or on-success, and not both"}
+    (fn [{:keys [path on-success]}]
+      (->> [path on-success]
+           (filter identity)
+           count
+           (= 1)))]])
+
+(def core-fsm-schema-def
+  [:map
+   [:max-retries {:default 0} :int]
+   [:retry-delay {:default 2000}
+    [:or
+     [:fn {:error/message "Should be a function of the number of retries"} fn?]
+     :int]]
+   [:state-path {:default [:>]}
+    [:vector :keyword]]])
+
+(def top-level-fsm-schema-def
+  [:map
+   [:id :keyword]])
+
+(def embedded-fsm-schema-def
+  [:map
+   [:failure-state {:optional true} [:vector :keyword]]
+   [:success-state {:optional true} [:vector :keyword]]])
+
+(def request-map-schema (m/schema request-map-schema-def))
+(def embedded-fsm-schema (mu/merge core-fsm-schema-def
+                                   embedded-fsm-schema-def))
+(def top-level-fsm-schema (mu/merge core-fsm-schema-def
+                                    top-level-fsm-schema-def))
+(def top-level-fsm-validation-schema (mu/optional-keys top-level-fsm-schema [:max-retries :retry-delay :state-path]))
+
+(defn- assert-schema [schema config message]
+  (when-let [errors (m/explain schema config)]
+    #_(prn ::throwing-schema (me/humanize errors))
+    (throw (ex-info message
+                    {:humanized (me/humanize errors)
+                     :data      errors}))))
+
+(defn fsm? [fsm]
+  (m/validate top-level-fsm-validation-schema fsm))
+
+(defn update-retries [state & _]
+  (update state :retries inc))
+
+(defn reset-retries [state & _]
+  (assoc state :retries 0))
+
+(defn more-retries? [max-retries {:keys [retries]} _]
+  (< retries max-retries))
+
+(defn store-error [state event]
+  (assoc state :error (:data event)))
+
+(defn- dispatch-callback [event-vector-name]
+  (fn [state event]
+    (when-let [event-vector (get-in state [:request event-vector-name])]
+      (f/dispatch (vec (concat event-vector [state event]))))))
+
+(defn dispatch-xhrio [state event]
+  (sc.rf/call-fx {:http-xhrio (get-in state [:request :http-xhrio])}))
+
+(defn embedded-fsm [{:keys [max-retries retry-delay
+                            state-path failure-state success-state]
+                     :as   config}]
+  (assert-schema embedded-fsm-schema config "Invalid embedded HTTP FSM")
+  (let [retry-delay (if (fn? retry-delay)
+                      (comp retry-delay :retries)
+                      retry-delay)]
+    {:initial ::loading
+     :states  {::loading {:entry [dispatch-xhrio
+                                  (dispatch-callback :on-loading)]
+                          :on    {::error   ::error
+                                  ::success (or success-state ::loaded)}}
+               ::error   {:initial ::retrying
+                          :entry   [(sc/assign store-error)
+                                    (dispatch-callback :on-error)]
+                          :states  {::retrying {:always  [{:guard  (fn [] (< max-retries 1))
+                                                           :target (or failure-state ::halted)}]
+                                                :initial ::waiting
+                                                :entry   (sc/assign reset-retries)
+                                                :states  {::loading {:entry [(sc/assign update-retries)
+                                                                             dispatch-xhrio]
+                                                                     :on    {::error   [{:guard  (partial more-retries? max-retries)
+                                                                                         :target ::waiting}
+                                                                                        (or failure-state (vec (concat state-path [::error ::halted])))]
+                                                                             ::success (or success-state (vec (concat state-path [::loaded])))}}
+                                                          ::waiting {:after [{:delay  retry-delay
+                                                                              :target ::loading}]}}}
+                                    ::halted   {:entry (dispatch-callback :on-failure)}}}
+               ::loaded  {:entry (fn [{{:keys [on-success]} :request} {:keys [data]}]
+                                   (f/dispatch (conj on-success data)))}}}))
+
+(defn fsm [{:keys [id] :as config}]
+  (assoc (embedded-fsm config) :id id))
+
+(defn machine-path [fsm-id]
+  (vec (concat [::fsm] (sc.utils/ensure-vector fsm-id))))
+
+(defn request-state-path [request-id]
+  (vec (concat [::fsm-state] (sc.utils/ensure-vector request-id))))
+
+(f/reg-event-db ::save-to-path (fn [db [_ path data]] (assoc-in db path data)))
+
+(defn expand-machine [config]
+  (assert-schema top-level-fsm-validation-schema config "Invalid HTTP FSM")
+  (-> (m/decode top-level-fsm-schema config mt/default-value-transformer)
+      fsm
+      sc/machine))
+
+(f/reg-event-fx
+ ::register
+ (fn [_ [_ fsm]]
+   (let [machine (expand-machine fsm)]
+     {:dispatch [::sc.rf/register (machine-path (:id machine)) machine]})))
+
+(defn- request-transition-data [request]
+  {:fsm-path   (machine-path (:fsm/id request))
+   :state-path (request-state-path (:request/id request))})
+
+(f/reg-fx
+ ::start
+ (fn [request]
+   (assert-schema request-map-schema request "Invalid HTTP request")
+   (let [transition-data (request-transition-data request)
+         request         (-> request
+                             ;; we are guaranteed to have :path or :on-success
+                             (update :on-success #(or % [::save-to-path (:path request)]))
+                             (assoc-in [:http-xhrio :on-success] [::sc.rf/transition ::success transition-data])
+                             (assoc-in [:http-xhrio :on-failure] [::sc.rf/transition ::error transition-data]))]
+     (f/dispatch [::sc.rf/initialize transition-data {:context {:request request}}]))))
+
+(f/reg-event-fx ::start (fn [_ [_ request]] {::start request}))
+
+(f/reg-event-fx ::restart
+  (fn [{:keys [db]} [_ request]]
+    (let [transition-data (request-transition-data request)]
+      (when-let [existing-context (get-in db (:state-path transition-data))]
+        {:dispatch [::sc.rf/initialize transition-data {:context existing-context}]}))))
+
+(f/reg-event-fx ::discard
+ ;; Removes the request identified by `request-id` from the app db. Does not
+ ;; attempt to halt an in-flight request.
+ (fn [_ [_ request-id]]
+   {:dispatch [::sc.rf/discard-state (request-state-path request-id)]}))
+
+(defn ->seq [x]
+  (if (coll? x)
+    x
+    [x]))
+
+(f/reg-sub ::state
+  (fn [db [_ request-id]]
+    (->seq (get-in db (conj (request-state-path request-id) :_state)))))
+
+(f/reg-sub ::state-full
+  (fn [db [_ request-id]]
+    (get-in db (request-state-path request-id))))

--- a/src/glimt/multi_state.cljc
+++ b/src/glimt/multi_state.cljc
@@ -8,23 +8,24 @@
             [statecharts.utils :as sc.utils]
             [statecharts.integrations.re-frame-multi :as sc.rf]))
 
-(def request-map-schema-def
-  [:and
-   [:map
-    [:fsm/id :keyword]
-    [:request/id vector?]
-    [:http-xhrio :map]
-    [:path {:optional true} vector?]
-    [:on-success {:optional true} vector?]
-    [:on-loading {:optional true} vector?]
-    [:on-error {:optional true} vector?]
-    [:on-failure {:optional true} vector?]]
-   [:fn {:error/message "Should contain either path or on-success, and not both"}
-    (fn [{:keys [path on-success]}]
-      (->> [path on-success]
-           (filter identity)
-           count
-           (= 1)))]])
+(def request-map-schema
+  (m/schema
+   [:and
+    [:map
+     [:fsm/id :keyword]
+     [:request/id vector?]
+     [:http-xhrio :map]
+     [:path {:optional true} vector?]
+     [:on-success {:optional true} vector?]
+     [:on-loading {:optional true} vector?]
+     [:on-error {:optional true} vector?]
+     [:on-failure {:optional true} vector?]]
+    [:fn {:error/message "Should contain either path or on-success, and not both"}
+     (fn [{:keys [path on-success]}]
+       (->> [path on-success]
+            (filter identity)
+            count
+            (= 1)))]]))
 
 (def core-fsm-schema-def
   [:map
@@ -36,21 +37,20 @@
    [:state-path {:default [:>]}
     [:vector :keyword]]])
 
-(def top-level-fsm-schema-def
-  [:map
-   [:id :keyword]])
+(def fsm-schema
+  (mu/merge
+   core-fsm-schema-def
+   [:map
+    [:id :keyword]]))
 
-(def embedded-fsm-schema-def
-  [:map
-   [:failure-state {:optional true} [:vector :keyword]]
-   [:success-state {:optional true} [:vector :keyword]]])
+(def fsm-validation-schema (mu/optional-keys fsm-schema [:max-retries :retry-delay :state-path]))
 
-(def request-map-schema (m/schema request-map-schema-def))
-(def embedded-fsm-schema (mu/merge core-fsm-schema-def
-                                   embedded-fsm-schema-def))
-(def top-level-fsm-schema (mu/merge core-fsm-schema-def
-                                    top-level-fsm-schema-def))
-(def top-level-fsm-validation-schema (mu/optional-keys top-level-fsm-schema [:max-retries :retry-delay :state-path]))
+(def embedded-fsm-schema
+  (mu/merge
+   core-fsm-schema-def
+   [:map
+    [:failure-state {:optional true} [:vector :keyword]]
+    [:success-state {:optional true} [:vector :keyword]]]))
 
 (defn- assert-schema [schema config message]
   (when-let [errors (m/explain schema config)]
@@ -60,7 +60,7 @@
                      :data      errors}))))
 
 (defn fsm? [fsm]
-  (m/validate top-level-fsm-validation-schema fsm))
+  (m/validate fsm-validation-schema fsm))
 
 (defn update-retries [state & _]
   (update state :retries inc))
@@ -80,9 +80,13 @@
 (defn dispatch-xhrio [state event]
   (sc.rf/call-fx {:http-xhrio (get-in state [:request :http-xhrio])}))
 
-(defn embedded-fsm [{:keys [max-retries retry-delay
-                            state-path failure-state success-state]
-                     :as   config}]
+(defn embedded-fsm
+  "Create an embedded machine as described by `config`. Will dispatch requests,
+  retrying on error if so configured, and store progress on the app-db. See
+  `::state` for details on fetching the progress."
+  [{:keys [max-retries retry-delay
+           state-path failure-state success-state]
+    :as   config}]
   (assert-schema embedded-fsm-schema config "Invalid embedded HTTP FSM")
   (let [retry-delay (if (fn? retry-delay)
                       (comp retry-delay :retries)
@@ -99,19 +103,23 @@
                                                            :target (or failure-state ::halted)}]
                                                 :initial ::waiting
                                                 :entry   (sc/assign reset-retries)
-                                                :states  {::loading {:entry [(sc/assign update-retries)
+                                                :states  {::waiting {:after [{:delay  retry-delay
+                                                                              :target ::loading}]}
+                                                          ::loading {:entry [(sc/assign update-retries)
                                                                              dispatch-xhrio]
                                                                      :on    {::error   [{:guard  (partial more-retries? max-retries)
                                                                                          :target ::waiting}
                                                                                         (or failure-state (vec (concat state-path [::error ::halted])))]
-                                                                             ::success (or success-state (vec (concat state-path [::loaded])))}}
-                                                          ::waiting {:after [{:delay  retry-delay
-                                                                              :target ::loading}]}}}
-                                    ::halted   {:entry (dispatch-callback :on-failure)}}}
-               ::loaded  {:entry (fn [{{:keys [on-success]} :request} {:keys [data]}]
-                                   (f/dispatch (conj on-success data)))}}}))
+                                                                             ::success (or success-state (vec (concat state-path [::loaded])))}}}}
+                                    ::halted {:entry (dispatch-callback :on-failure)}}}
+               ::loaded {:entry (fn [{{:keys [on-success]} :request} {:keys [data]}]
+                                  (f/dispatch (conj on-success data)))}}}))
 
-(defn fsm [{:keys [id] :as config}]
+(defn fsm
+  "Create a machine as described by `config`. Will dispatch requests, retrying
+  on error if so configured, and store progress on the app-db. See `::state` for
+  details on fetching the progress."
+  [{:keys [id] :as config}]
   (assoc (embedded-fsm config) :id id))
 
 (defn machine-path [fsm-id]
@@ -120,14 +128,14 @@
 (defn request-state-path [request-id]
   (vec (concat [::fsm-state] (sc.utils/ensure-vector request-id))))
 
-(f/reg-event-db ::save-to-path (fn [db [_ path data]] (assoc-in db path data)))
-
 (defn expand-machine [config]
-  (assert-schema top-level-fsm-validation-schema config "Invalid HTTP FSM")
-  (-> (m/decode top-level-fsm-schema config mt/default-value-transformer)
+  (assert-schema fsm-validation-schema config "Invalid HTTP FSM")
+  (-> (m/decode fsm-schema config mt/default-value-transformer)
       fsm
       sc/machine))
 
+;; Register an FSM. After being registered, the `fsm` can be used to `::start`
+;; requests.
 (f/reg-event-fx
  ::register
  (fn [_ [_ fsm]]
@@ -138,6 +146,9 @@
   {:fsm-path   (machine-path (:fsm/id request))
    :state-path (request-state-path (:request/id request))})
 
+;; Helper for requests that specify a `:path` instead of an `:on-success`.
+(f/reg-event-db ::save-to-path (fn [db [_ path data]] (assoc-in db path data)))
+
 (f/reg-fx
  ::start
  (fn [request]
@@ -146,33 +157,47 @@
          request         (-> request
                              ;; we are guaranteed to have :path or :on-success
                              (update :on-success #(or % [::save-to-path (:path request)]))
-                             (assoc-in [:http-xhrio :on-success] [::sc.rf/transition ::success transition-data])
-                             (assoc-in [:http-xhrio :on-failure] [::sc.rf/transition ::error transition-data]))]
+                             (update :http-xhrio assoc
+                                     :on-success [::sc.rf/transition ::success transition-data]
+                                     :on-failure [::sc.rf/transition ::error transition-data]))]
      (f/dispatch [::sc.rf/initialize transition-data {:context {:request request}}]))))
 
+;; Start a request, storing it and its state in the DB.
 (f/reg-event-fx ::start (fn [_ [_ request]] {::start request}))
 
-(f/reg-event-fx ::restart
-  (fn [{:keys [db]} [_ request]]
-    (let [transition-data (request-transition-data request)]
-      (when-let [existing-context (get-in db (:state-path transition-data))]
-        {:dispatch [::sc.rf/initialize transition-data {:context existing-context}]}))))
+;; Restart a request, which presumably finished either at [::error ::halted] or
+;; [::loaded]. Note that the entire request isn't needed, only the `:request/id`
+;; and `:fsm/id`. If you want to change any parameters of the request, dispatch
+;; `::start` instead.
+(f/reg-event-fx
+ ::restart
+ (fn [{:keys [db]} [_ request]]
+   (let [transition-data (request-transition-data request)]
+     (when-let [existing-context (get-in db (:state-path transition-data))]
+       {:dispatch [::sc.rf/initialize transition-data {:context existing-context}]}))))
 
-(f/reg-event-fx ::discard
- ;; Removes the request identified by `request-id` from the app db. Does not
- ;; attempt to halt an in-flight request.
+;; Removes the request identified by `request-id` from the app db. Does not
+;; attempt to halt an in-flight request, though any transitions for the request
+;; will be dropped.
+(f/reg-event-fx
+ ::discard
  (fn [_ [_ request-id]]
    {:dispatch [::sc.rf/discard-state (request-state-path request-id)]}))
 
-(defn ->seq [x]
-  (if (coll? x)
-    x
-    [x]))
+;; Get the progress of the request identified by `request-id`. Should be one of:
+;; [::loading]
+;; [::error ::retrying ::waiting]
+;; [::error ::retrying ::loading]
+;; [::error ::halted]
+;; [::loaded]
+(f/reg-sub
+ ::state
+ (fn [db [_ request-id]]
+   (sc.utils/ensure-vector (get-in db (conj (request-state-path request-id) :_state)))))
 
-(f/reg-sub ::state
-  (fn [db [_ request-id]]
-    (->seq (get-in db (conj (request-state-path request-id) :_state)))))
-
-(f/reg-sub ::state-full
-  (fn [db [_ request-id]]
-    (get-in db (request-state-path request-id))))
+;; Get the full state of the request identified by `request-id`. Includes the
+;; progress at :_state
+(f/reg-sub
+ ::state-full
+ (fn [db [_ request-id]]
+   (get-in db (request-state-path request-id))))


### PR DESCRIPTION
For context on this PR see:
1. https://github.com/ingesolvoll/glimt/pull/3
2. https://github.com/ingesolvoll/glimt/discussions/4
3. https://github.com/lucywang000/clj-statecharts/pull/7

This uses a new integration between re-frame and clj-statecharts, one which stores the machine and state in the app-db. It will **not** be mergable until that new integration has been merged into clj-statecharts (see https://github.com/lucywang000/clj-statecharts/pull/7).

The value of doing it this way is mostly in the new integration. This integration registers only a few event handlers. Those same event handlers can transition any machine and state, though they have to be told which machine and state to act upon.

This lets glimt avoid accumulating handlers in the global event handler registry, and lets it provide tools to discard unused machines and states. Users of glimt can then manage hundreds or thousands of separate requests, without worrying about memory leaks.

The prior discussions have brought up a few possibilities which I want to discuss more here.

## `glimt` API

@ingesolvoll you asked whether it would be possible to expose a single event (`::start`) instead of two (`::register` and `::start`). This new code expose two events, but let's discuss reducing to one. I think it's possible. The glimt `::start` handler could dispatch both `::register` and `::initialize` to `clj-statecharts.integrations.re-frame-multi`. We'd have to separate the `::start` parameters into those appropriate for `::register` and those for `::initialize`. And we'd have to decide whether to clobber any existing machine with the same `:fsm/id`. Interestingly, I don't think clobbering it would hurt anything... in-flight requests would just start using the new machine. If the retry configuration changed it would change those requests too, but that'd probably be ok.

## single machine

The code in this PR splits up the configuration into two parts: configuration for machines, which includes retry data and data for working in an embedded machine; and configuration for requests, which includes the `:http-xhrio` object and callbacks to dispatch upon state transition.

But @ingesolvoll you suggested the possibility of having just a single machine for all of `glimt`. The configuration for retries and embedded machines would live not in the machine but _on the request's state_. I've just started thinking about this, but if it's possible, I think it would solve a lot of problems.

The way I envision it working is that `:glimt.multi-state/start` would look exactly like `:glimt.core/start`. That is, you wouldn't specify an fsm-id. And instead of having the `:id` be a keyword, it could be a vector, the same as what I've been calling `:request/id`: a path into the app-db where the request and its progress should be stored.

Note that this resolves the above question about whether glimt exposes one or two events. With a single machine, you'd only need one `::start` event.

I'll do some research into whether it's possible to move the retry and embedded machine data into the request state. But let's talk about drawbacks too... Having a single glimt machine would limit the ability to use [clj-statecharts "epochs"](https://lucywang000.github.io/clj-statecharts/docs/integration/re-frame/#discard-stale-events-with-epoch-support), its tool for discarding stale events. At least as defined in https://github.com/lucywang000/clj-statecharts/pull/7, the current epoch is stored on the machine, so if you advance the epoch on the glimt machine, you'd end up dropping the transitions for all in-flight requests. If you have several machines, you can advance the epoch of just one, abandoning only the requests associated with it. On the other hand, glimt doesn't currently take advantage of epochs, and in my opinion, the whole idea of epochs is kind of an edge case. If a glimt user really wanted epochs, they could implement them themselves. They would store an epoch or a family of epochs in their app-db, and make their `:on-success` and `:on-failure` callbacks check whether they're from the right epoch before continuing. As of right now, I don't see any other drawbacks. I'll report back on the research.

Note that this approach will still need the changes in https://github.com/lucywang000/clj-statecharts/pull/7. The original `clj-statecharts` integration with `re-frame` and the revised integration in [`kee-frame.fsm.beta`](https://github.com/ingesolvoll/kee-frame/blob/master/src/kee_frame/fsm/beta.cljc) both suffer from the same problem: one machine can manage only a _single_ state in the app-db, a problem which is fixed by https://github.com/lucywang000/clj-statecharts/pull/7. That is, with those other integrations if we had only one machine we could track the progress of only one request at a time, which isn't very useful.

The especially intriguing thing about not having to specify the fsm-id is that the new implementation could be a drop-in replacement for `glimt.core`. It could even replace `glimt.core`. The schema for `glimt.core` would expand to allow the request `:id` to be vectors of keywords, not just keywords, but otherwise the API would stay the same. Kind of an exciting possibility.

## naming

I've been reconsidering the keywords `:fsm/id` and `:request/id`. I'm partial to namespaced keywords, but it's a departure from the rest of glimt. I'm thinking about switching them to `:fsm-id` and `:request-id`. What do you think? The question is irrelevant if we're able to make the "single machine" idea above work. Then the we don't need a machine id, and can just call the request id "`:id`"

## automatic state disposal

I think it would be nice to be able to instruct glimt to remove the request from the app-db after some amount of time in the `[::error ::halted]` or `[::loaded]` states. That'll be possible with https://github.com/lucywang000/clj-statecharts/pull/7, but in any case, it's an enhancement that can be put in a later PR.